### PR TITLE
[Draft] Update getAncestors() to sort nodes in order they appears in the path by default

### DIFF
--- a/lib/mpath.js
+++ b/lib/mpath.js
@@ -288,7 +288,7 @@ function mpathPlugin(schema, options) {
       conditions,
       fields,
       options
-    );
+    ).then(nodes => ancestorIds.map(id => nodes.find(n => n._id.toHexString() === id)));
   };
 
   /**


### PR DESCRIPTION
Thanks for great lib! Current implementation of `getAncestors()` sort nodes on _id field, which depends on create time. After parent change ancestors can change its order which is confusing. I think user expects to get ancestors in order they appear in the path.